### PR TITLE
Use "queue a global task" instead of "queue a task"

### DIFF
--- a/floc.bs
+++ b/floc.bs
@@ -82,11 +82,11 @@ spec:webidl; type:dfn; text:resolve
         - The <a href="#cohort-assignment-algorithm">cohort assignment algorithm</a> is unavailable.
 
         then:
-          1. [=Queue a task=] on the <dfn>interest cohort task source</dfn> to [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
+          1. [=Queue a global task=] on the <dfn>interest cohort task source</dfn> given [=this=]'s [=relevant global object=] to [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
           1. Abort these steps.
     1. Let |id| be [=interest cohort id=] from running the <a href="#cohort-assignment-algorithm">cohort assignment algorithm</a>.
     1. Let |version| be the [=interest cohort version=] corresponding to the <a href="#cohort-assignment-algorithm">cohort assignment algorithm</a>.
-    1. [=Queue a task=] on the [=interest cohort task source=] to perform the following steps:
+    1. [=Queue a global task=] on the [=interest cohort task source=] given [=this=]'s [=relevant global object=] to perform the following steps:
         1. Let |d| be the {{InterestCohort}} dictionary, with {{InterestCohort/id}} being the <a href="#string-representation-of-the-interest-cohort-id">string representation</a> of |id|, and {{InterestCohort/version}} being <a href="#string-representation-of-the-interest-cohort-version">string representation</a> of |version|.
         1. [=Resolve=] |p| with |d|.
   1. Return |p|.


### PR DESCRIPTION
This is more explicit and preferred these days. See https://github.com/whatwg/html/pull/6402.

---

I realized I didn't encourage the right pattern here in the review, so I thought I'd send a quick PR to fix it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/domenic/floc/pull/46.html" title="Last updated on Feb 22, 2021, 5:03 PM UTC (293edb6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/floc/46/8de4b46...domenic:293edb6.html" title="Last updated on Feb 22, 2021, 5:03 PM UTC (293edb6)">Diff</a>