### PR TITLE
add sync condition that account is not a child

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ For Chrome’s POC, cohorts will be logged with sync in a limited set of circums
 1. The user’s [Google Ad Settings](https://adssettings.google.com/) have the following enabled:
     1. “Ad Personalization”
     1. “Also use your activity & information from Google services to personalize ads on websites and apps that partner with Google to show ads.” 
+1. The user is not a child account
 
 ### Sites which interest cohorts will be calculated on
 All sites with publicly routable IP addresses that the user visits when not in incognito mode will be included in the POC cohort calculation. 


### PR DESCRIPTION
`floc_event_logger.h` defines the following conditions for the sync permission.
The fourth condition is missing, and this fix adds it.

```
// computed. For each logging request, a floc is eligible to be logged if the
// following conditons are met:
// 1) Sync & sync-history are enabled.
// 2) Supplemental Web and App Activity is enabled.
// 3) Supplemental Ad Personalization is enabled.
// 4) The account type is NOT a child account.
```